### PR TITLE
Add data_chopper module for distributing data to MPI ranks

### DIFF
--- a/thechopper/__init__.py
+++ b/thechopper/__init__.py
@@ -1,3 +1,4 @@
 """For further details about thechopper, see https://www.youtube.com/watch?v=-9-Te-DPbSE
 """
 from .buffered_subvolume_calculations import *
+from .data_chopper import *

--- a/thechopper/buffered_subvolume_calculations.py
+++ b/thechopper/buffered_subvolume_calculations.py
@@ -1,16 +1,19 @@
-"""Functions used to decompose the domain of a three-dimensional rectangular volume
-with periodic boundary conditions.
-"""
+"""Functions chop simulation data into subvolumes for independent processing."""
 import numpy as np
 
 
-__all__ = ('rectangular_subvolume_cellnum', 'points_in_buffered_rectangle',
-        'points_in_rectangle', 'subvol_bounds_generator')
+__all__ = ('calculate_subvolume_id', 'points_in_buffered_rectangle',
+           'points_in_rectangle')
 
 
-def rectangular_subvolume_cellnum(x, y, z, nx, ny, nz, period):
-    """After wrapping the input x, y, z into the periodic box, assign each point
-    to a rectangular subvolume defined by the number of subdivisions in each dimension.
+def calculate_subvolume_id(x, y, z, nx, ny, nz, period):
+    """Calculate the subvolume ID for every input point.
+
+    The function first wraps the input x, y, z into the periodic box,
+    then assigns each point to a rectangular subvolume according to
+    the number of subdivisions in each dimension.
+    The subvolume ID is defined by a dictionary ordering of the
+    digitized values of x, y, z.
 
     Parameters
     ----------
@@ -19,6 +22,7 @@ def rectangular_subvolume_cellnum(x, y, z, nx, ny, nz, period):
     nx, ny, nz : integers
 
     period : float or 3-element sequence
+        Length of the periodic box
 
     Returns
     -------
@@ -32,12 +36,9 @@ def rectangular_subvolume_cellnum(x, y, z, nx, ny, nz, period):
     cellnum : ndarray of shape (npts, )
         Integer array that by itself specifies the subvolume of each point,
         e.g., (ix, iy, iz)=(0, 0, 0) <==> cellnum=0
+
     """
-    period = np.atleast_1d(period)
-    if period.shape[0] == 1:
-        period = np.zeros(3) + period[0]
-    elif period.shape[0] != 3:
-        raise ValueError("period should be float or 3-element sequence")
+    period = _get_3_element_sequence(period)
 
     x = np.atleast_1d(np.mod(x, period[0]))
     y = np.atleast_1d(np.mod(y, period[1]))
@@ -51,13 +52,15 @@ def rectangular_subvolume_cellnum(x, y, z, nx, ny, nz, period):
     iy = np.floor(_rescaled_y).astype('i4')
     iz = np.floor(_rescaled_z).astype('i4')
 
-    cellnum = np.ravel_multi_index( (ix, iy, iz), (nx, ny, nz) )
+    cellnum = np.ravel_multi_index((ix, iy, iz), (nx, ny, nz))
     return x, y, z, ix, iy, iz, cellnum
 
 
-def points_in_buffered_rectangle(x, y, z, xyz_mins, xyz_maxs, rmax_xyz, period_xyz):
-    """Return the subset of points inside a rectangular subvolume
-    surrounded by a buffer region, accounting for periodic boundary conditions.
+def points_in_buffered_rectangle(x, y, z, xyz_mins, xyz_maxs, rmax_xyz, period):
+    """Return the subset of points inside a buffered rectangular subvolume.
+
+    All returned points will lie within rmax_xyz of (xyz_mins, xyz_maxs),
+    accounting for periodic boundary conditions.
 
     Parameters
     ----------
@@ -75,17 +78,19 @@ def points_in_buffered_rectangle(x, y, z, xyz_mins, xyz_maxs, rmax_xyz, period_x
         Search radius distance in the xyz direction.
         Must have rmax_xyz <= period_xyz/2.
 
-    period_xyz : 3-element sequence
+    period : float or 3-element sequence
         Length of the periodic box
 
     Returns
     -------
     xout, yout, zout : ndarrays, each with shape (npts_buffered_subvol, )
-        Coordinates of points that lie within the search radius of the rectangular subvolume.
+        Coordinates of points that lie within the buffered subvolume.
 
-        The returned points will lie in the range [xyz_mins-rmax_xyz, xyz_maxs+rmax_xyz],
-        which may spill beyond the range [0, Lbox], as required by the size of
-        the search radius, the size of the box, and the position of the subvolume.
+        The returned points will lie in the range
+        [xyz_mins-rmax_xyz, xyz_maxs+rmax_xyz]. Note that this may spill beyond
+        the range [0, Lbox], as required by the size of
+        the search radius, the size of the box,
+        and the position of the subvolume.
 
         The buffered subvolume includes all points relevant to pair-counting
         within rmax_xyz for points in the rectangular subvolume,
@@ -99,12 +104,13 @@ def points_in_buffered_rectangle(x, y, z, xyz_mins, xyz_maxs, rmax_xyz, period_x
 
     inside_subvol : ndarray, shape (npts_buffered_subvol, )
         boolean array is True when the point is in the rectangular subvolume,
-        False when the point is in the +/-rmax_xyz region surrounding the rectangular subvolume.
+        False when the point is in the +/-rmax_xyz buffering region.
+
     """
+    period_xyz = _get_3_element_sequence(period)
     xyz_mins = np.array(xyz_mins)
     xyz_maxs = np.array(xyz_maxs)
     rmax_xyz = np.array(rmax_xyz)
-    period_xyz = np.array(period_xyz)
     x = np.mod(x, period_xyz[0])
     y = np.mod(y, period_xyz[1])
     z = np.mod(z, period_xyz[2])
@@ -115,11 +121,13 @@ def points_in_buffered_rectangle(x, y, z, xyz_mins, xyz_maxs, rmax_xyz, period_x
     indx_collector = []
     in_subvol_collector = []
 
-    for subregion in _buffering_rectangular_subregions(xyz_mins, xyz_maxs, rmax_xyz):
+    for subregion in _buffering_rectangular_subregions(
+            xyz_mins, xyz_maxs, rmax_xyz):
         subregion_ix_iy_iz, subregion_xyz_mins, subregion_xyz_maxs = subregion
 
-        subregion_x, subregion_y, subregion_z, subregion_indx = points_in_rectangle(
+        _points = points_in_rectangle(
             x, y, z, subregion_xyz_mins, subregion_xyz_maxs, period_xyz)
+        subregion_x, subregion_y, subregion_z, subregion_indx = _points
 
         _npts = len(subregion_x)
         if _npts > 0:
@@ -128,7 +136,9 @@ def points_in_buffered_rectangle(x, y, z, xyz_mins, xyz_maxs, rmax_xyz, period_x
             z_collector.append(subregion_z)
             indx_collector.append(subregion_indx)
 
-            in_subvol = np.zeros_like(subregion_x).astype(bool) + (subregion_ix_iy_iz == (0, 0, 0))
+            in_subvol = (np.zeros_like(subregion_x).astype(bool)
+                         + (subregion_ix_iy_iz == (0, 0, 0)))
+
             in_subvol_collector.append(in_subvol)
 
     if len(x_collector) == 0:
@@ -147,11 +157,12 @@ def points_in_buffered_rectangle(x, y, z, xyz_mins, xyz_maxs, rmax_xyz, period_x
     return xout, yout, zout, indx, inside_subvol
 
 
-def points_in_rectangle(x, y, z, xyz_mins, xyz_maxs, period_xyz):
-    """Return the set of all points located in the rectangular subvolume [xyz_mins, xyz_maxs).
+def points_in_rectangle(x, y, z, xyz_mins, xyz_maxs, period):
+    """Return the subset of points inside a buffered rectangular subvolume.
 
     Periodic boundary conditions are accounted for by including any points that
-    fall inside the subvolume when one or more the coordinates is shifted by +/- period.
+    fall inside the subvolume when one or more the coordinates
+    is shifted by +/- period.
 
     Parameters
     ----------
@@ -165,7 +176,7 @@ def points_in_rectangle(x, y, z, xyz_mins, xyz_maxs, period_xyz):
         xyz coordinates of the upper corner of the rectangular subvolume.
         Must have 0 <= xyz_mins <= xyz_maxs <= period_xyz
 
-    period_xyz : 3-element sequence
+    period : float or 3-element sequence
         Length of the periodic box
 
     Returns
@@ -176,10 +187,11 @@ def points_in_rectangle(x, y, z, xyz_mins, xyz_maxs, period_xyz):
 
     indx : ndarray, shape (npts_subvol, )
         index of the corresponding point in the input xyz arrays
+
     """
+    period_xyz = _get_3_element_sequence(period)
     xyz_mins = np.array(xyz_mins)
     xyz_maxs = np.array(xyz_maxs)
-    period_xyz = np.array(period_xyz)
 
     x_collector = []
     y_collector = []
@@ -189,7 +201,8 @@ def points_in_rectangle(x, y, z, xyz_mins, xyz_maxs, period_xyz):
     npts_input_data = len(x)
     available_indices = np.arange(npts_input_data).astype(int)
 
-    for mask, shift in _pbc_generator_mask_and_shift(x, y, z, xyz_mins, xyz_maxs, period_xyz):
+    for mask, shift in _pbc_generator_mask_and_shift(
+            x, y, z, xyz_mins, xyz_maxs, period_xyz):
 
         _npts = np.count_nonzero(mask)
         if _npts > 0:
@@ -211,32 +224,12 @@ def points_in_rectangle(x, y, z, xyz_mins, xyz_maxs, period_xyz):
     return xout, yout, zout, indx
 
 
-def subvol_bounds_generator(rank, nranks, num_xdivs, num_ydivs, num_zdivs, period):
-    """
-    """
-    num_tot_subvols = num_xdivs*num_ydivs*num_zdivs
-    subvol_indices_all = np.arange(num_tot_subvols)
-    subvol_indices_rank = np.array_split(subvol_indices_all, nranks)[rank]
-
-    for subvol_indx in subvol_indices_rank:
-        ix, iy, iz = np.unravel_index(
-            subvol_indx, (num_xdivs, num_ydivs, num_zdivs) )
-        xlo, xhi = _get_subvol_bounds_1d(ix, period[0], num_xdivs)
-        ylo, yhi = _get_subvol_bounds_1d(iy, period[1], num_ydivs)
-        zlo, zhi = _get_subvol_bounds_1d(iz, period[2], num_zdivs)
-        xyz_mins = (xlo, ylo, zlo)
-        xyz_maxs = (xhi, yhi, zhi)
-        yield subvol_indx, xyz_mins, xyz_maxs
-
-
-def _get_subvol_bounds_1d(ip, dim_length, dim_ndivs):
-    ds = dim_length/float(dim_ndivs)
-    return ip*ds, (ip+1)*ds
-
-
 def _pbc_generator_mask_and_shift(x, y, z, xyz_mins, xyz_maxs, period_xyz):
-    """Generate masks for 27 rectangular subvolumes obtained by
-    by shifting the input rectangular subvolume by +/0/- period in each dimension
+    """Generate masks for 27 rectangular subvolumes.
+
+    Masks are obtained by shifting the input rectangular subvolume
+    by +/0/- period in each dimension.
+
     """
     for bounds in _pbc_generator_xyz_bounds(xyz_mins, xyz_maxs, period_xyz):
         subvol_xyz_shift, subvol_xyz_mins, subvol_xyz_maxs = bounds
@@ -253,9 +246,7 @@ def _pbc_generator_mask_and_shift(x, y, z, xyz_mins, xyz_maxs, period_xyz):
 
 
 def _pbc_generator_xyz_bounds(xyz_mins, xyz_maxs, period_xyz):
-    """Generate the bounds for 27 rectangular subvolumes obtained by
-    by shifting the input rectangular subvolume by +/0/- period in each dimension
-    """
+    """Generate xyz bounds for 27 rectangular subvolumes."""
     for ix in (-1, 0, 1):
         xmin = xyz_mins[0] + ix*period_xyz[0]
         xmax = xyz_maxs[0] + ix*period_xyz[0]
@@ -272,36 +263,43 @@ def _pbc_generator_xyz_bounds(xyz_mins, xyz_maxs, period_xyz):
 
 
 def _buffering_rectangular_subregions(xyz_mins, xyz_maxs, rmax_xyz):
-    """Decompose the buffered subvolume into 27 subregions:
-    one subregion for the subvolume itself, and the remaining 26 come from
-    the rectanguloids adjacent to each face, edge, and corner.
+    """Decompose the buffered subvolume into 27 subregions.
 
-    In particular, our buffered subvolume is decomposed into the following 27 subregions:
+    There will be one subregion for the subvolume itself,
+    and the remaining 26 come from the rectangles adjacent to
+    each face, edge, and corner:
 
-    * 1 for the data in the rectangular subvolume specified by (xyz_mins, xyz_maxs);
-    * 6 for the buffer data in the region rmax_xyz beyond each face of the rectangular subvolume;
-    * 12 for the buffer data in the region rmax_xyz beyond each edge of the rectangular subvolume;
-    * 8 for the buffer data in the region rmax_xyz beyond each corner of the rectangular subvolume;
+    * 1 for the data in (xyz_mins, xyz_maxs);
+    * 6 for the buffer data in the region rmax_xyz beyond each face;
+    * 12 for the buffer data in the region rmax_xyz beyond each edge;
+    * 8 for the buffer data in the region rmax_xyz beyond each corner;
 
-    The _buffering_rectangular_subregions generator loops over these 27 subvolumes,
+    The generator loops over these 27 subvolumes,
     and yields their xyz boundaries.
+
     """
     for ix in (-1, 0, 1):
-        xmin, xmax = _get_buffering_subregion_minmax(ix, xyz_mins[0], xyz_maxs[0], rmax_xyz[0])
+        xmin, xmax = _get_buffering_subregion_minmax(
+            ix, xyz_mins[0], xyz_maxs[0], rmax_xyz[0])
 
         for iy in (-1, 0, 1):
-            ymin, ymax = _get_buffering_subregion_minmax(iy, xyz_mins[1], xyz_maxs[1], rmax_xyz[1])
+            ymin, ymax = _get_buffering_subregion_minmax(
+                iy, xyz_mins[1], xyz_maxs[1], rmax_xyz[1])
 
             for iz in (-1, 0, 1):
-                zmin, zmax = _get_buffering_subregion_minmax(iz, xyz_mins[2], xyz_maxs[2], rmax_xyz[2])
+                zmin, zmax = _get_buffering_subregion_minmax(
+                    iz, xyz_mins[2], xyz_maxs[2], rmax_xyz[2])
 
                 yield (ix, iy, iz), (xmin, ymin, zmin), (xmax, ymax, zmax)
 
 
 def _get_buffering_subregion_minmax(ip, pmin, pmax, rmax):
-    """Given a line segment (pmin, pmax) buffered by a region rmax,
-    calculate the segment (smin, smax) that either buffers or duplicates (pmin, pmax),
-    depending on the input variable ip.
+    """Return the min/max bounds of a buffering line segment.
+
+    Given a line segment (pmin, pmax) buffered by a region rmax,
+    calculate the segment (smin, smax) that either buffers or duplicates
+    (pmin, pmax) according to the input variable ip.
+
     """
     if ip == -1:
         smin, smax = pmin - rmax, pmin
@@ -310,3 +308,18 @@ def _get_buffering_subregion_minmax(ip, pmin, pmax, rmax):
     elif ip == 1:
         smin, smax = pmax, pmax + rmax
     return smin, smax
+
+
+def _get_3_element_sequence(s):
+    """Return a 3-element sequence defined by s.
+
+    If s is already a 3-element sequence, return s unchanged.
+    If s is a scalar, return [s, s, s].
+
+    """
+    s_xyz = np.atleast_1d(s)
+    if s_xyz.size == 1:
+        s_xyz = np.array((s_xyz[0], s_xyz[0], s_xyz[0]))
+    elif s_xyz.size != 3:
+        raise ValueError("quantity must be a float or 3-element sequence")
+    return s_xyz

--- a/thechopper/data_chopper.py
+++ b/thechopper/data_chopper.py
@@ -1,0 +1,293 @@
+"""Functions distribute chopped simulation data to MPI ranks."""
+import numpy as np
+from collections import OrderedDict
+from .buffered_subvolume_calculations import points_in_buffered_rectangle
+
+
+__all__ = ('get_buffered_subvolumes', 'get_all_chopped_data')
+
+
+def get_buffered_subvolumes(comm, catalog, nx, ny, nz, period, rmax,
+                           colnames='all', source_rank=0):
+    """Get the buffered subvolume data assigned to the MPI rank.
+
+    Parameters
+    ----------
+    comm : MPI communicator
+
+    catalog : dict
+        For rank == source_rank, keys are column names, values are ndarrays.
+        For rank != source_rank, should be an empty dict.
+
+    nx, ny, nz : integers
+        Specify how to decompose the simulation into subvolumes
+
+    period : Float or 3-element sequence
+        Length of the periodic box in each dimension.
+        Box will be assumed to be a cube if period is a float.
+
+    rmax : Float or 3-element sequence
+        Search radius in each Cartesian direction.
+        Must have rmax <= period/2 in each dimension.
+
+    colnames : string or list of strings, optional
+        Specifies which columns to distribute to the ranks.
+        Default is all columns.
+
+    source_rank : int, optional
+        Rank in possession of the catalog data. Default is 0.
+
+    Returns
+    -------
+    datalist : list
+        List with length equal to the number of subvolumes assigned to the rank.
+        Each element is a dictionary storing catalog data in the subvolume.
+
+    ranklist : list
+        List with length equal to the number of subvolumes assigned to the rank.
+        Each element is an integer providing the subvolume ID.
+
+    """
+    rank, nranks = comm.Get_rank(), comm.Get_size()
+    if colnames == 'all':
+        colnames = sorted(list(catalog.keys()))
+    else:
+        colnames = [s for s in np.atleast_1d(colnames)]
+
+    if rank == source_rank:
+        chopped_cat = get_all_chopped_data(
+            catalog, nx, ny, nz, period, rmax, colnames)
+    else:
+        chopped_cat = OrderedDict()
+
+    data_collection = []
+    num_subvols = nx*ny*nz
+    for isubvol in range(0, num_subvols):
+        cat_to_send = OrderedDict(((key, chopped_cat[key][isubvol]))
+                                  for key in chopped_cat.keys())
+        dest_rank = _get_rank_responsible_for_subvol_id(
+            isubvol, nx, ny, nz, nranks)
+        if dest_rank == 0:
+            data_collection.append(cat_to_send)
+        else:
+            recv_cat = _distribute_simdata(
+                comm, cat_to_send, source_rank, dest_rank)
+            data_collection.append(recv_cat)
+
+    datalist = list((d for d in data_collection if len(list(d.keys())) > 0))
+    ranklist = list((i for i, d in enumerate(data_collection)
+                     if len(list(d.keys())) > 0))
+    return datalist, ranklist
+
+
+def get_all_chopped_data(data, nx, ny, nz, period, rmax, colnames):
+    """
+    Divide the input data into a collection of buffered subvolumes.
+
+    Parameters
+    ----------
+    data : dict
+        Keys are names of galaxy/halo properties. Values are ndarrays.
+
+    nx, ny, nz : integers
+        Number of divisions of the periodic box in each dimension
+
+    period : Float or 3-element sequence
+        Length of the periodic box in each dimension.
+        Box will be assumed to be a cube if period is a float.
+
+    rmax : Float or 3-element sequence
+        Search radius in each Cartesian direction.
+        Must have rmax <= period/2 in each dimension.
+
+    colnames : list of strings
+
+    Returns
+    -------
+    chopped_data : dict
+        Keys are names of galaxy/halo properties.
+        The value bound to each key is a list with length equal to the
+        total number of subvolumes: nx*ny*nz. Each element of the list stores
+        a (possibly empty) ndarray storing data belonging to
+        the corresponding buffered subvolume.
+
+    """
+    period_xyz = _get_3_element_sequence(period)
+    rmax_xyz = _get_3_element_sequence(rmax)
+
+    #  Wrap xyz into the box before assigning data to subvolumes
+    data['x'] = data['x'] % period_xyz[0]
+    data['y'] = data['y'] % period_xyz[1]
+    data['z'] = data['z'] % period_xyz[2]
+
+    #  Assign data to subvolumes
+    dx = float(period_xyz[0]/nx)
+    dy = float(period_xyz[1]/ny)
+    dz = float(period_xyz[2]/nz)
+    _ix = np.array(data['x'] // dx).astype(int)
+    _iy = np.array(data['y'] // dy).astype(int)
+    _iz = np.array(data['z'] // dz).astype(int)
+    data['_ix'] = _ix
+    data['_iy'] = _iy
+    data['_iz'] = _iz
+
+    #  columns_to_retrieve always has the following columns:
+    #   _ix, _iy, _iz, _inside_subvol, _subvol_indx
+    #  xyz get remapped and so will be treated separately
+    _always = {'x', 'y', 'z', '_inside_subvol', '_subvol_indx'}
+    _s = set(colnames) - _always
+    _cellids = {'_ix', '_iy', '_iz'}
+    _t = _s.union(_cellids)
+    columns_to_retrieve = list(_t)
+
+    chopped_data = OrderedDict(((key, [])) for key in columns_to_retrieve)
+    chopped_data['x'] = []
+    chopped_data['y'] = []
+    chopped_data['z'] = []
+    chopped_data['_inside_subvol'] = []
+    chopped_data['_subvol_indx'] = []
+
+    gen = _subvol_bounds_generator(nx, ny, nz, period_xyz)
+    for subvol_bounds in gen:
+        subvol_indx, xyz_mins, xyz_maxs = subvol_bounds
+
+        _ret = points_in_buffered_rectangle(
+            data['x'], data['y'], data['z'],
+            xyz_mins, xyz_maxs, rmax_xyz, period_xyz)
+        xout, yout, zout, indx, inside_subvol = _ret
+
+        chopped_data['x'].append(xout)
+        chopped_data['y'].append(yout)
+        chopped_data['z'].append(zout)
+        chopped_data['_inside_subvol'].append(inside_subvol)
+
+        _subvol_indx = np.zeros(xout.size).astype(int) + subvol_indx
+        chopped_data['_subvol_indx'].append(_subvol_indx)
+
+        for colname in columns_to_retrieve:
+            chopped_data[colname].append(data[colname][indx])
+
+    return chopped_data
+
+
+def _distribute_simdata(comm, halo_catalog, source, dest,
+                        tag=0, columns_to_send='all'):
+    """Send data in the halo_catalog from source rank to destination rank.
+
+    Parameters
+    ----------
+    comm : MPI communicator
+
+    halo_catalog : dict
+        Each key is a halo property, each value an ndarray of shape (nhalos, )
+
+    source : int
+        Rank of the sender
+
+    dest : int
+        Rank of the receiver
+
+    tag : int, optional
+        Tag to use in the message passing. Default is 0.
+
+    columns_to_send : string or list of strings, optional
+        Default is 'all', for sending all the arrays in halo_catalog
+
+    Returns
+    -------
+    recv_halocat : dict
+        One key for each value in columns_to_send.
+        Each value will be an ndarray of shape (nhalos, )
+
+    """
+    rank = comm.Get_rank()
+
+    if columns_to_send == 'all':
+        columns_to_send = sorted(list(halo_catalog.keys()))
+    else:
+        columns_to_send = [s for s in np.atleast_1d(columns_to_send)]
+
+    if rank == source:
+        recv_halocat = OrderedDict()
+
+        ncols_to_send = len(columns_to_send)
+        comm.send(ncols_to_send, dest=dest, tag=tag)
+
+        for send_colname in columns_to_send:
+            send_arr = halo_catalog[send_colname]
+            send_npts, send_dtype = send_arr.size, str(send_arr.dtype)
+            comm.send(send_colname, dest=dest, tag=tag)
+            comm.send(send_npts, dest=dest, tag=tag)
+            comm.send(send_dtype, dest=dest, tag=tag)
+            comm.Send(send_arr, dest=dest, tag=tag)
+
+    elif rank == dest:
+        recv_halocat = OrderedDict()
+
+        ncols_to_recv = comm.recv(source=source, tag=tag)
+
+        for __ in range(ncols_to_recv):
+            recv_colname = comm.recv(source=source, tag=tag)
+            npts_to_recv = comm.recv(source=source, tag=tag)
+            dtype_to_recv = comm.recv(source=source, tag=tag)
+            recvarray = np.zeros(npts_to_recv).astype(dtype_to_recv)
+            comm.Recv(recvarray, source=source, tag=tag)
+            recv_halocat[recv_colname] = recvarray
+
+    else:
+        recv_halocat = OrderedDict()
+
+    return recv_halocat
+
+
+def _subvol_bounds_generator(nx, ny, nz, period):
+    """For every subvolume, yield its ID and its xyz bounds."""
+    num_tot_subvols = nx*ny*nz
+    subvol_ids = np.arange(num_tot_subvols)
+
+    for subvol_id in subvol_ids:
+        ix, iy, iz = np.unravel_index(
+            subvol_id, (nx, ny, nz) )
+        xlo, xhi = _get_subvol_bounds_1d(ix, period[0], nx)
+        ylo, yhi = _get_subvol_bounds_1d(iy, period[1], ny)
+        zlo, zhi = _get_subvol_bounds_1d(iz, period[2], nz)
+        xyz_mins = (xlo, ylo, zlo)
+        xyz_maxs = (xhi, yhi, zhi)
+        yield subvol_id, xyz_mins, xyz_maxs
+
+
+def _get_subvol_bounds_1d(ip, dim_length, dim_ndivs):
+    """Get the boundaries of a 1-d line segment."""
+    ds = dim_length/float(dim_ndivs)
+    return ip*ds, (ip+1)*ds
+
+
+def _get_subvol_ids_assigned_to_ranks(nx, ny, nz, nranks):
+    """Assign subvolumes to the available ranks."""
+    ndivs_total = nx*ny*nz
+    subvol_ids_assigned_to_rank = np.array_split(
+        np.arange(ndivs_total), nranks)
+    return subvol_ids_assigned_to_rank
+
+
+def _get_rank_responsible_for_subvol_id(subvol_ID, nx, ny, nz, nranks):
+    """Find the reank responsible for the subvolume."""
+    cells_assigned_to_ranks = _get_subvol_ids_assigned_to_ranks(
+        nx, ny, nz, nranks)
+    _x = [subvol_ID in arr for arr in cells_assigned_to_ranks]
+    return _x.index(True)
+
+
+def _get_3_element_sequence(s):
+    """Return a 3-element sequence defined by s.
+
+    If s is already a 3-element sequence, return s unchanged.
+    If s is a scalar, return [s, s, s].
+
+    """
+    s_xyz = np.atleast_1d(s)
+    if s_xyz.size == 1:
+        s_xyz = np.array((s_xyz[0], s_xyz[0], s_xyz[0]))
+    elif s_xyz.size != 3:
+        raise ValueError("quantity must be a float or 3-element sequence")
+    return s_xyz

--- a/thechopper/tests/test_buffered_subvolume_calculations.py
+++ b/thechopper/tests/test_buffered_subvolume_calculations.py
@@ -3,7 +3,7 @@
 import numpy as np
 from scipy.spatial import cKDTree
 from ..buffered_subvolume_calculations import points_in_buffered_rectangle
-from ..buffered_subvolume_calculations import rectangular_subvolume_cellnum
+from ..buffered_subvolume_calculations import calculate_subvolume_id
 
 
 def generate_3d_regular_mesh(npts_per_dim, dmin, dmax):
@@ -92,7 +92,7 @@ def test1():
 
 
 def test2():
-    """Require that the rectangular_subvolume_cellnum function
+    """Require that the calculate_subvolume_id function
     returns a cellnum array with all points lying within [0, nx*ny*nz)
     """
     rng = np.random.RandomState(43)
@@ -103,7 +103,7 @@ def test2():
     y = rng.uniform(0, period[1], npts)
     z = rng.uniform(0, period[2], npts)
     nx, ny, nz = 5, 6, 7
-    _result = rectangular_subvolume_cellnum(x, y, z, nx, ny, nz, period)
+    _result = calculate_subvolume_id(x, y, z, nx, ny, nz, period)
     x2, y2, z2, ix, iy, iz, cellnum = _result
     assert np.all(cellnum >= 0)
     assert np.all(cellnum < nx*ny*nz)
@@ -113,7 +113,7 @@ def test2():
 
 
 def test3():
-    """Require that rectangular_subvolume_cellnum function wraps xyz points
+    """Require that calculate_subvolume_id function wraps xyz points
     lying outside the box back into the box.
     """
     Lbox = 1.
@@ -124,7 +124,7 @@ def test3():
     z[0] = -0.5
 
     nx, ny, nz = npts_per_dim, npts_per_dim, npts_per_dim
-    _result = rectangular_subvolume_cellnum(x, y, z, nx, ny, nz, Lbox)
+    _result = calculate_subvolume_id(x, y, z, nx, ny, nz, Lbox)
     x2, y2, z2, ix, iy, iz, cellnum = _result
     assert np.all(cellnum >= 0)
     assert np.all(cellnum < nx*ny*nz)
@@ -138,14 +138,14 @@ def test3():
 
 def test4():
     """Place a single point at the center of each subvolume and ensure that
-    the cellnum array returned by rectangular_subvolume_cellnum is correct.
+    the cellnum array returned by calculate_subvolume_id is correct.
     """
     Lbox = 1.
     npts_per_dim = 5
     x, y, z = generate_3d_regular_mesh(npts_per_dim, 0, Lbox)
 
     nx, ny, nz = npts_per_dim, npts_per_dim, npts_per_dim
-    _result = rectangular_subvolume_cellnum(x, y, z, nx, ny, nz, Lbox)
+    _result = calculate_subvolume_id(x, y, z, nx, ny, nz, Lbox)
     x2, y2, z2, ix, iy, iz, cellnum = _result
 
     #  Every cell gets exactly one point


### PR DESCRIPTION
New module can be used to chop up a chunk of data into buffered subvolumes, and then distribute them to MPI ranks for independent processing.